### PR TITLE
fix: Correct Workload Identity Federation configuration for CI/CD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,9 @@ jobs:
       uses: google-github-actions/auth@v2
       with:
         # The Workload Identity Provider resource name.
+        # This now uses a single secret GCP_WORKLOAD_IDENTITY_PROVIDER.
         # Format: projects/{project-number}/locations/global/workloadIdentityPools/{pool-id}/providers/{provider-id}
-        workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ secrets.GCP_WIF_POOL_ID }}/providers/${{ secrets.GCP_WIF_PROVIDER_ID }}'
+        workload_identity_provider: '${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}'
         # The service account to impersonate.
         service_account: '${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}'
 

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -29,7 +29,9 @@ jobs:
       uses: google-github-actions/auth@v2
       with:
         # The Workload Identity Provider resource name.
-        workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ secrets.GCP_WIF_POOL_ID }}/providers/${{ secrets.GCP_WIF_PROVIDER_ID }}'
+        # This now uses a single secret GCP_WORKLOAD_IDENTITY_PROVIDER.
+        # Format: projects/{project-number}/locations/global/workloadIdentityPools/{pool-id}/providers/{provider-id}
+        workload_identity_provider: '${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}'
         # The service account to impersonate. Must have permissions to destroy resources.
         service_account: '${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}'
 

--- a/README.md
+++ b/README.md
@@ -151,12 +151,13 @@ Ensure your `terraform/terraform.tfvars` is correctly populated.
 The project is configured with GitHub Actions for automated deployment on pushes to the `main` branch.
 *   **Workflow:** `.github/workflows/deploy.yml`
 *   **Authentication:** Uses Workload Identity Federation to authenticate with GCP.
-*   **Secrets:** You need to configure the following secrets in your GitHub repository settings (refer to the comments in `.github/workflows/deploy.yml` for exact secret names like `GCP_PROJECT_ID`, `GCP_PROJECT_NUMBER`, `GCP_WIF_POOL_ID`, `GCP_WIF_PROVIDER_ID`, `GCP_SERVICE_ACCOUNT_EMAIL`):
-    *   `GCP_PROJECT_ID`: Your Google Cloud Project ID.
-    *   `GCP_PROJECT_NUMBER`: Your Google Cloud Project Number.
-    *   `GCP_WIF_POOL_ID`: Your Workload Identity Pool ID.
-    *   `GCP_WIF_PROVIDER_ID`: Your Workload Identity Pool Provider ID (associated with your GitHub repo).
-    *   `GCP_SERVICE_ACCOUNT_EMAIL`: The email of the GCP service account that GitHub Actions will impersonate. This service account must have the necessary permissions to deploy resources and be configured as a principal in the Workload Identity Pool.
+*   **Secrets:** You need to configure the following secrets in your GitHub repository settings (`Settings > Secrets and variables > Actions`):
+    *   `GCP_PROJECT_ID`: Your Google Cloud Project ID (e.g., `my-gcp-project-123`).
+    *   `GCP_WORKLOAD_IDENTITY_PROVIDER`: The full resource name of your Workload Identity Pool Provider. This is used by GitHub Actions to securely authenticate with Google Cloud.
+        *   Format: `projects/YOUR_PROJECT_NUMBER/locations/global/workloadIdentityPools/YOUR_POOL_ID/providers/YOUR_PROVIDER_ID`
+        *   Example: `projects/123456789012/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider`
+    *   `GCP_SERVICE_ACCOUNT_EMAIL`: The email of the GCP service account that GitHub Actions will impersonate. This service account must have the necessary permissions to manage resources defined in the Terraform configuration.
+        *   Example: `terraform-runner@my-gcp-project-123.iam.gserviceaccount.com`
 *   The workflow will build and push the Docker image and then run `terraform apply`.
 
 ## API Usage


### PR DESCRIPTION
This commit fixes a CI/CD failure caused by an incorrect Workload Identity Federation (WIF) setup in the GitHub Actions workflows.

The key changes are:

1.  **Simplified WIF Secret:**
    *   The `deploy.yml` and `destroy.yml` workflows now use a single
        GitHub secret `GCP_WORKLOAD_IDENTITY_PROVIDER` to store the full
        Workload Identity Provider resource name.
    *   This replaces the previous method of constructing the WIF provider
        path from three separate secrets (`GCP_PROJECT_NUMBER`,
        `GCP_WIF_POOL_ID`, `GCP_WIF_PROVIDER_ID`), which was prone to
        errors if any of the secrets were unset.

2.  **Updated Documentation:**
    *   The `README.md` has been updated to reflect this change, instructing
        you to configure the `GCP_WORKLOAD_IDENTITY_PROVIDER` secret
        with the full WIF provider string.

This change should resolve the "Invalid value for 'audience'" error and ensure the CI/CD pipeline can correctly authenticate with Google Cloud.